### PR TITLE
Use std OnceLock instead of once_cell module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "compiler-tools"
 version = "0.1.7"
 dependencies = [
- "once_cell",
  "regex",
  "serde",
 ]
@@ -59,12 +58,6 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "once_cell"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "proc-macro2"

--- a/compiler-tools-derive/src/gen/full_regex.rs
+++ b/compiler-tools-derive/src/gen/full_regex.rs
@@ -19,7 +19,7 @@ pub(crate) fn gen_full_regex(
             let fn_ident = format_ident!("parse_r_{}", item.ident);
             let regex_fn = quote! {
                 fn #fn_ident(from: &str) -> Option<(&str, &str)> {
-                    static REGEX: ::compiler_tools::once_cell::sync::OnceCell<::compiler_tools::regex::Regex> = ::compiler_tools::once_cell::sync::OnceCell::new();
+                    static REGEX: ::std::sync::OnceLock<::compiler_tools::regex::Regex> = ::std::sync::OnceLock::new();
                     let regex = REGEX.get_or_init(|| ::compiler_tools::regex::Regex::new(#regex).unwrap());
                     if let Some(matching) = regex.find(from) {
                         assert_eq!(matching.start(), 0);

--- a/compiler-tools/Cargo.toml
+++ b/compiler-tools/Cargo.toml
@@ -11,8 +11,7 @@ keywords = [ "compiler", "parser", "generator" ]
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 regex = { version = "1.5", optional = true }
-once_cell = { version = "1.10", optional = true }
 
 [features]
 default = ["serde", "use_regex"]
-use_regex = ["regex", "once_cell"]
+use_regex = ["regex"]

--- a/compiler-tools/src/lib.rs
+++ b/compiler-tools/src/lib.rs
@@ -11,8 +11,4 @@ pub mod util;
 
 #[cfg(feature = "use_regex")]
 #[doc(hidden)]
-pub use once_cell;
-
-#[cfg(feature = "use_regex")]
-#[doc(hidden)]
 pub use regex;


### PR DESCRIPTION
Since Rust `1.70` we can get rid of `once_cell` by using [OnceLock](https://doc.rust-lang.org/std/sync/struct.OnceLock.html) directly from std.