### PR TITLE
Track MSRV in Cargo.toml

### DIFF
--- a/compiler-tools-derive/Cargo.toml
+++ b/compiler-tools-derive/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Protryon/compiler-tools"
 description = "A proc-macro for deriving powerful and fast tokenizers with compile-time regex"
 keywords = [ "compiler", "parser", "generator" ]
+rust-version = "1.75.0"
 
 [lib]
 proc-macro = true

--- a/compiler-tools/Cargo.toml
+++ b/compiler-tools/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Protryon/compiler-tools"
 description = "A proc-macro for deriving powerful and fast tokenizers with compile-time regex"
 keywords = [ "compiler", "parser", "generator" ]
+rust-version = "1.75.0"
 
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }


### PR DESCRIPTION
Although it is possible to put the minimum version 1.70 because of https://github.com/Protryon/compiler-tools/pull/3, I think it is a good starting point to put 1.75.