### PR TITLE
Fix newline span tracking and harden the simple-regex engine

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,72 @@
+# Improvements backlog
+
+Ergonomics and feature ideas surfaced during an audit of the workspace. These are
+**not** bugs (the confirmed bugs from that audit are already fixed); they are API and
+feature gaps worth prioritizing. Roughly ordered by impact.
+
+## API ergonomics
+
+### 1. Implement `Iterator` for the generated tokenizer and `TokenizerWrap`
+Today both expose an inherent `next(&self) -> Option<Spanned<..>>`, so every consumer
+hand-writes `while let Some(t) = tok.next() { .. }`. Implementing `Iterator` (and
+`IntoIterator`) on the generated `XxxTokenizer` and on `TokenizerWrap` would unlock
+`for`, `collect`, `map`, `filter`, `peekable`, etc. for free. This is the single
+biggest ergonomic win.
+
+- Generated tokenizer: `compiler-tools-derive/src/lib.rs` (the `impl TokenParse` block).
+- Wrapper: `compiler-tools/src/tokenizer.rs`.
+
+### 2. Distinguish "lex error" from "end of input"
+With no `#[token(illegal)]` handler, `next()` returns `None` both at EOF *and* when it
+is stuck on an unmatchable character with input still remaining. The two are
+indistinguishable, so a malformed input looks like a clean, short token stream.
+
+Options:
+- Expose the remaining input / position (e.g. `fn remaining(&self) -> &str`,
+  `fn is_exhausted(&self) -> bool`) so callers can detect a stuck tokenizer.
+- Offer a `Result`-returning variant of `next` that reports the offending span.
+
+### 3. Grammar-level `#[token(skip)]`
+Whitespace currently has to be wired up by hand via
+`TokenizerWrap::new(inner, [Token::Ws])`. A `#[token(skip)]` attribute (or generating
+the ignore-list from the grammar) would be more discoverable and harder to get wrong.
+
+## Correctness / fidelity
+
+### 4. Character columns instead of byte columns
+Span columns are byte offsets, not character counts (see the `//todo: handle utf8`
+markers in `codegen/simple_regex.rs`, `codegen/full_regex.rs`, and `lib.rs`). For
+non-ASCII source this yields misleading column numbers. The newline column math is now
+correct in *bytes*; converting to character columns is a separate, larger change that
+touches all four span-emission sites.
+
+## Custom regex engine features
+
+### 5. Alternation and grouping
+The custom `#[token(regex = ...)]` engine supports literals, classes/ranges, negation,
+`.`, and `* + ?`, but has **no alternation or grouping** — users are forced onto the
+slower `regex_full` (the `regex` crate) for those. Adding `(...)` groups and `a|b`
+alternation to `simple_regex/parse.rs` + `nfa.rs` would let more grammars stay on the
+fast, allocation-free path. Most-requested feature, largest effort.
+
+### 6. Named character classes
+`simple_regex/mod.rs` already carries a `// TODO: we should support classes (i.e.
+unicode ident_start)`. Shorthands like `\d \w \s` (and ideally Unicode classes such as
+`ident_start`/`ident_continue`) would remove a lot of verbose `[a-zA-Z0-9_]` patterns.
+
+## Macro diagnostics (polish)
+
+### 7. Honor or reject the attribute-macro arguments
+`token_parse(_metadata, input)` silently ignores `_metadata`
+(`compiler-tools-derive/src/lib.rs`), so `#[token_parse(anything)]` is accepted with no
+effect. Either give the args meaning or emit a `compile_error!` for non-empty args.
+
+### 8. Fix a misleading `compile_error!` message
+The `regex_full` parse-failure arm reports `"invalid simple regex"`
+(`compiler-tools-derive/src/lib.rs`, the `Regex::new` error branch); it should say
+`"invalid regex"` since that path uses the full `regex` crate, not the simple engine.
+
+### 9. Better parse-failure diagnostics for payload `.parse()`
+Variants whose payload type needs `.parse()` reject a match on parse failure with no
+explanation (`//TODO: emit better error for parsefail` in `lib.rs` and `lit_table.rs`).
+A clearer message — or a way to surface the underlying parse error — would help.

--- a/compiler-tools-derive/src/codegen/full_regex.rs
+++ b/compiler-tools-derive/src/codegen/full_regex.rs
@@ -41,9 +41,10 @@ pub(crate) fn gen_full_regex(
                         self.line
                     },
                     //todo: handle utf8 better with newline seeking here
-                    col_stop: if let Some(newline_offset) = passed.as_bytes().iter().rev().position(|x| *x == b'\n') {
-                        let newline_offset = passed.len() - newline_offset;
-                        self.col = (newline_offset as u64).saturating_sub(1);
+                    col_stop: if let Some(trailing_bytes) = passed.as_bytes().iter().rev().position(|x| *x == b'\n') {
+                        // `trailing_bytes` is the number of bytes after the last newline,
+                        // which is the column on the final line.
+                        self.col = trailing_bytes as u64;
                         self.col
                     } else {
                         self.col += passed.len() as u64;

--- a/compiler-tools-derive/src/codegen/simple_regex.rs
+++ b/compiler-tools-derive/src/codegen/simple_regex.rs
@@ -31,9 +31,10 @@ pub(crate) fn gen_simple_regex(
                             self.line
                         },
                         //todo: handle utf8 better with newline seeking here
-                        col_stop: if let Some(newline_offset) = passed.as_bytes().iter().rev().position(|x| *x == b'\n') {
-                            let newline_offset = passed.len() - newline_offset;
-                            self.col = (newline_offset as u64).saturating_sub(1);
+                        col_stop: if let Some(trailing_bytes) = passed.as_bytes().iter().rev().position(|x| *x == b'\n') {
+                            // `trailing_bytes` is the number of bytes after the last newline,
+                            // which is the column on the final line.
+                            self.col = trailing_bytes as u64;
                             self.col
                         } else {
                             self.col += passed.len() as u64;

--- a/compiler-tools-derive/src/lib.rs
+++ b/compiler-tools-derive/src/lib.rs
@@ -339,7 +339,7 @@ fn impl_token_parse(input: &DeriveInput) -> proc_macro2::TokenStream {
     for (token_index, item) in tokens_to_parse.iter().enumerate() {
         for regex in &item.regexes {
             let modified_regex = format!("^{}", regex);
-            let parsed = match Regex::new(&*modified_regex) {
+            let parsed = match Regex::new(&modified_regex) {
                 Ok(x) => x,
                 Err(_) => {
                     return quote_spanned! {
@@ -376,7 +376,7 @@ fn impl_token_parse(input: &DeriveInput) -> proc_macro2::TokenStream {
             }
             let mut any_matched = false;
             for ((ident, raw_regex), regex) in &simple_regexes {
-                if regex.token_index > token_index && regex.regex.matches(&**literal) {
+                if regex.token_index > token_index && regex.regex.matches(literal) {
                     simple_regex_ident_conflicts
                         .entry((ident.clone(), raw_regex.clone()))
                         .or_default()
@@ -388,7 +388,7 @@ fn impl_token_parse(input: &DeriveInput) -> proc_macro2::TokenStream {
                 continue;
             }
             for ((ident, raw_regex), regex) in &regexes {
-                if regex.token_index > token_index && regex.regex.is_match(&**literal) {
+                if regex.token_index > token_index && regex.regex.is_match(literal) {
                     regex_ident_conflicts
                         .entry((ident.clone(), raw_regex.clone()))
                         .or_default()
@@ -399,7 +399,7 @@ fn impl_token_parse(input: &DeriveInput) -> proc_macro2::TokenStream {
             if any_matched {
                 continue;
             }
-            lit_table.push(item, &**literal, &mut literal.chars());
+            lit_table.push(item, literal, &mut literal.chars());
         }
     }
 
@@ -501,7 +501,7 @@ fn impl_token_parse(input: &DeriveInput) -> proc_macro2::TokenStream {
 
     for (token_index, token) in tokens_to_parse.iter().enumerate() {
         if let Some(parse_fn) = &token.parse_fn {
-            let path_expr: ExprPath = match syn::parse_str(&parse_fn) {
+            let path_expr: ExprPath = match syn::parse_str(parse_fn) {
                 Ok(x) => x,
                 Err(_e) => {
                     parse_fns
@@ -523,9 +523,10 @@ fn impl_token_parse(input: &DeriveInput) -> proc_macro2::TokenStream {
                                 self.line
                             },
                             //todo: handle utf8 better with newline seeking here
-                            col_stop: if let Some(newline_offset) = passed.as_bytes().iter().rev().position(|x| *x == b'\n') {
-                                let newline_offset = passed.len() - newline_offset;
-                                self.col = (newline_offset as u64).saturating_sub(1);
+                            col_stop: if let Some(trailing_bytes) = passed.as_bytes().iter().rev().position(|x| *x == b'\n') {
+                                // `trailing_bytes` is the number of bytes after the last newline,
+                                // which is the column on the final line.
+                                self.col = trailing_bytes as u64;
                                 self.col
                             } else {
                                 self.col += passed.len() as u64;
@@ -562,9 +563,10 @@ fn impl_token_parse(input: &DeriveInput) -> proc_macro2::TokenStream {
                         self.col
                     } else {
                         //todo: handle utf8 better with newline seeking here
-                        let newline_offset = self.inner[..self.inner.len() - remaining.len()].as_bytes().iter().rev().position(|x| *x == b'\n').expect("malformed newline state");
-                        let newline_offset = (self.inner.len() - remaining.len()) - newline_offset;
-                        self.col = (newline_offset as u64).saturating_sub(1);
+                        // `trailing_bytes` is the number of bytes after the last newline in the
+                        // matched literal, which is the column on the final line.
+                        let trailing_bytes = self.inner[..self.inner.len() - remaining.len()].as_bytes().iter().rev().position(|x| *x == b'\n').expect("malformed newline state");
+                        self.col = trailing_bytes as u64;
                         self.col
                     },
                 };

--- a/compiler-tools-derive/src/lit_table.rs
+++ b/compiler-tools-derive/src/lit_table.rs
@@ -115,7 +115,7 @@ impl LitTable {
 
     //TODO: straightshot optimization
     pub(super) fn emit(&self, fn_name: &Ident, enum_ident: &Ident) -> TokenStream {
-        let internal = self.emit_internal(&enum_ident, None);
+        let internal = self.emit_internal(enum_ident, None);
         // println!("{}", internal);
         quote! {
             // returns (token, remaining, newlines_skipped)

--- a/compiler-tools-derive/src/simple_regex/dfa.rs
+++ b/compiler-tools-derive/src/simple_regex/dfa.rs
@@ -44,7 +44,7 @@ impl Dfa {
                 .map(|(shadowed, shadows)| {
                     (
                         epsilon_closure.get(shadowed).unwrap().clone().1,
-                        shadows.into_iter().map(|shadow| epsilon_closure.get(shadow).unwrap().clone()).collect(),
+                        shadows.iter().map(|shadow| epsilon_closure.get(shadow).unwrap().clone()).collect(),
                     )
                 })
                 .collect();
@@ -52,6 +52,7 @@ impl Dfa {
             let total = epsilon_closure.len();
             let mut emitted_closures = vec![];
             while emitted_closures.len() < total {
+                let progress_before = emitted_closures.len();
                 for i in 0..total {
                     if !epsilon_closure.contains_key(&i) {
                         continue;
@@ -62,6 +63,17 @@ impl Dfa {
                             shadowing.retain(|x| *x != i);
                         }
                     }
+                }
+                // A pass that emits nothing means the remaining closures shadow each other
+                // in a cycle, so no priority ordering exists. Break the tie by emitting them
+                // in index order rather than spinning forever.
+                if emitted_closures.len() == progress_before {
+                    for i in 0..total {
+                        if let Some(closure) = epsilon_closure.remove(&i) {
+                            emitted_closures.push(closure);
+                        }
+                    }
+                    break;
                 }
             }
             emitted_closures.reverse();

--- a/compiler-tools-derive/src/simple_regex/matching.rs
+++ b/compiler-tools-derive/src/simple_regex/matching.rs
@@ -10,43 +10,25 @@ impl SimpleRegex {
                     }
                 }
                 Atom::Group(inverted, entries) => {
-                    if *inverted {
-                        for entry in entries {
-                            match entry {
-                                GroupEntry::Char(c) => {
-                                    if *c == '\n' {
-                                        return false;
-                                    }
-                                }
-                                GroupEntry::Range(start, end) => {
-                                    if *start <= '\n' && *end >= '\n' {
-                                        return false;
-                                    }
-                                }
-                            }
-                        }
+                    let entries_contain_newline = entries.iter().any(|entry| match entry {
+                        GroupEntry::Char(c) => *c == '\n',
+                        GroupEntry::Range(start, end) => *start <= '\n' && *end >= '\n',
+                    });
+                    // A negated class matches '\n' unless it explicitly excludes it; a normal
+                    // class matches '\n' only when it lists it. Either way, a non-capturing
+                    // atom must fall through so a later atom can still capture a newline.
+                    if entries_contain_newline != *inverted {
                         return true;
-                    } else {
-                        for entry in entries {
-                            let matched = match entry {
-                                GroupEntry::Char(c) => *c == '\n',
-                                GroupEntry::Range(start, end) => *start <= '\n' && *end >= '\n',
-                            };
-                            if matched {
-                                return true;
-                            }
-                        }
                     }
                 }
             }
         }
-        return false;
+        false
     }
 
     pub fn matches(&self, from: &str) -> bool {
         let mut state = 0u32;
-        let mut chars = from.chars();
-        while let Some(char) = chars.next() {
+        for char in from.chars() {
             for (transition, target) in self.dfa.transitions.get(&state).unwrap() {
                 if transition.matches(char) {
                     state = *target;
@@ -88,6 +70,10 @@ mod tests {
         assert!(!newline_capture("[^\n]*"));
         // a negated class that does not exclude '\n' can
         assert!(newline_capture("[^a]"));
+        // Regression: a newline-bearing atom *after* a newline-excluding negated class
+        // must still be detected (the scan used to stop at the first negated class).
+        assert!(newline_capture("[^\n]*\n"));
+        assert!(newline_capture("[^\n]*[\n]"));
     }
 
     #[test]

--- a/compiler-tools-derive/src/simple_regex/nfa.rs
+++ b/compiler-tools-derive/src/simple_regex/nfa.rs
@@ -60,7 +60,7 @@ pub struct Nfa {
 
 fn event_from_atom(atom: &Atom) -> Vec<TransitionEvent> {
     match atom {
-        Atom::Literal(l) => l.chars().map(|x| TransitionEvent::Char(x)).collect(),
+        Atom::Literal(l) => l.chars().map(TransitionEvent::Char).collect(),
         Atom::Group(inverted, entries) => {
             vec![TransitionEvent::Chars(*inverted, entries.clone())]
         }

--- a/compiler-tools-derive/src/simple_regex/parse.rs
+++ b/compiler-tools-derive/src/simple_regex/parse.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+/// Pops the pending `Char('-')` and the range's start char off `entries`, returning
+/// the start char. Returns `None` on a malformed state rather than panicking, so a bad
+/// pattern surfaces as a `compile_error!` instead of an ICE-style proc-macro panic.
+fn pop_range_start(entries: &mut Vec<GroupEntry>) -> Option<char> {
+    match (entries.pop(), entries.pop()) {
+        (Some(GroupEntry::Char('-')), Some(GroupEntry::Char(start))) => Some(start),
+        _ => None,
+    }
+}
+
 fn parse_group(iter: &mut impl Iterator<Item = char>) -> Option<Atom> {
     let mut group_entries = vec![];
     let mut escaped = false;
@@ -22,13 +32,7 @@ fn parse_group(iter: &mut impl Iterator<Item = char>) -> Option<Atom> {
             }
             Some(c) => {
                 if in_range {
-                    assert_eq!(group_entries.pop(), Some(GroupEntry::Char('-')));
-                    let start = group_entries.pop().expect("malformed state during group formation");
-                    let start = if let GroupEntry::Char(c) = start {
-                        c
-                    } else {
-                        panic!("malformed state during group formation");
-                    };
+                    let start = pop_range_start(&mut group_entries)?;
                     in_range = false;
                     group_entries.push(GroupEntry::Range(start, c))
                 } else {
@@ -41,13 +45,7 @@ fn parse_group(iter: &mut impl Iterator<Item = char>) -> Option<Atom> {
     }
     if escaped {
         if in_range {
-            assert_eq!(group_entries.pop(), Some(GroupEntry::Char('-')));
-            let start = group_entries.pop().expect("malformed state during group formation");
-            let start = if let GroupEntry::Char(c) = start {
-                c
-            } else {
-                panic!("malformed state during group formation");
-            };
+            let start = pop_range_start(&mut group_entries)?;
             group_entries.push(GroupEntry::Range(start, '\\'))
         } else {
             group_entries.push(GroupEntry::Char('\\'));

--- a/compiler-tools-derive/tests/behavior.rs
+++ b/compiler-tools-derive/tests/behavior.rs
@@ -187,6 +187,20 @@ fn illegal_tokens_track_lines_and_columns() {
 }
 
 #[test]
+fn spans_track_newline_within_multichar_token() {
+    // Regression: a single token that contains a newline followed by more text must
+    // reset the column to the number of characters *after* the last newline, not to
+    // the newline's own offset. Here the `Ws` token is "\n  " (newline + two spaces).
+    let spans = lex_spans("a\n  bc");
+    assert_eq!(spans.len(), 3);
+    // The whitespace ends on line 1 at column 2 (past the two spaces).
+    assert_eq!((spans[1].span.line_stop, spans[1].span.col_stop), (1, 2));
+    // "bc" therefore starts at column 2, not column 0.
+    assert_eq!((spans[2].span.line_start, spans[2].span.col_start), (1, 2));
+    assert_eq!((spans[2].span.line_stop, spans[2].span.col_stop), (1, 4));
+}
+
+#[test]
 fn no_lifetime_grammar_lexes() {
     let toks: Vec<Sym> = {
         let mut tokenizer = SymTokenizer::new("..@");

--- a/compiler-tools/src/tokenizer.rs
+++ b/compiler-tools/src/tokenizer.rs
@@ -29,6 +29,9 @@ impl<'a, T: TokenParse<'a>> TokenizerWrap<'a, T> {
         }
     }
 
+    // Deliberately an inherent method rather than an `Iterator::next`; see IMPROVEMENTS.md
+    // item 1 for the (separate) work of giving the wrapper a real `Iterator` impl.
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<Spanned<T::Token>> {
         if let Some(peeked) = self.peeked.take() {
             Some(peeked)


### PR DESCRIPTION
## Bugs fixed

**Newline column tracking was wrong.** The "this token contains a newline" column-reset computed the byte index *of* the last newline (`passed.len() - offset` then `.saturating_sub(1)`) instead of the count of bytes *after* it. Any single token containing a newline followed by more text (e.g. a whitespace run `"\n  "`, or a comment ending in a newline) mis-set the column for every following token. Fixed at all four span-emission sites — `codegen/simple_regex.rs`, `codegen/full_regex.rs`, and both the `parse_fn` and `lit_table` paths in `lib.rs`. Verified with `lex_spans("a\n  bc")`: `bc` was reported at column 0 and is now correctly at column 2.

**`could_capture_newline` returned prematurely on the first inverted group.** Both outcomes of the negated-class branch `return`ed, so the scan never looked past the first negated class. A newline-bearing atom *after* a newline-excluding class (e.g. `[^\n]*\n`) was missed, sending the token down the fast no-newline span path and breaking line tracking. Now only returns `true` when an atom can actually match `\n`.

## Robustness

- **DFA construction could hang** on a mutual-shadow cycle (two transitions that shadow each other). A pass that makes no progress now breaks the tie in index order instead of spinning forever.
- **`parse_group` ICE-style panics** replaced with a helper returning `Option`, so a malformed pattern surfaces as a `compile_error!` rather than a proc-macro panic.

## Also

- Fixes all pre-existing `clippy` warnings across both crates (the one intentional `should_implement_trait` case on `TokenizerWrap::next` is `#[allow]`'d with a note).
- Adds `IMPROVEMENTS.md` capturing the ergonomics/feature backlog (Iterator impls, lex-error vs EOF, `#[token(skip)]`, char vs byte columns, regex alternation/grouping, etc.).
- Adds regression tests for both bugs.

Note: `matches()`'s last-match-wins behavior was left as-is — its sole caller (compile-time keyword/ident conflict detection) depends on the current prefix-match semantics, which the committed tests assert.

## Verification
- 85 tests pass (24 + 43 + 13 + 2 + 3)
- `cargo clippy --all --all-features` clean
- `cargo +nightly-2025-03-01 fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)